### PR TITLE
fix: separate WASM and Server localization services to resolve DI err…

### DIFF
--- a/src/ui/iPath.Blazor.Client/Layout/MainLayout.razor
+++ b/src/ui/iPath.Blazor.Client/Layout/MainLayout.razor
@@ -71,7 +71,7 @@
 </MudLayout>
 
 
-@inject iPath.Blazor.ServiceLib.Services.StringLocalizerService srvLoc
+@inject iPath.Blazor.ServiceLib.Services.ClientStringLocalizerService srvLoc
 @inject IOptions<iPathClientConfig> opts
 @inject IOptions<LocalizationSettings> locOpts
 @inject AppState appState

--- a/src/ui/iPath.Blazor.Client/Program.cs
+++ b/src/ui/iPath.Blazor.Client/Program.cs
@@ -52,7 +52,7 @@ app.Services.InitComponenetsExtensions();
 // Preload localization data for WebAssembly client
 try
 {
-    var srvLoc = (iPath.Blazor.ServiceLib.Services.StringLocalizerService?)app.Services.GetService(typeof(iPath.Blazor.ServiceLib.Services.StringLocalizerService));
+    var srvLoc = (iPath.Blazor.ServiceLib.Services.ClientStringLocalizerService?)app.Services.GetService(typeof(iPath.Blazor.ServiceLib.Services.ClientStringLocalizerService));
     if (srvLoc != null)
     {
         var currentCulture = System.Globalization.CultureInfo.CurrentUICulture.TwoLetterISOLanguageName;

--- a/src/ui/iPath.Blazor.ServiceLib/Services/ClientStringLocalizerService.cs
+++ b/src/ui/iPath.Blazor.ServiceLib/Services/ClientStringLocalizerService.cs
@@ -1,0 +1,111 @@
+using iPath.Application.Localization;
+using Microsoft.Extensions.Localization;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using System.Collections.Concurrent;
+
+namespace iPath.Blazor.ServiceLib.Services;
+
+public class ClientStringLocalizerService : IStringLocalizer
+{
+    private readonly ILocalizationDataProvider _provider;
+    private readonly IOptions<LocalizationSettings> _opts;
+    private readonly ILogger<ClientStringLocalizerService> _logger;
+    private readonly ConcurrentDictionary<string, TranslationData> _translationsData = new();
+
+    public ClientStringLocalizerService(
+        ILocalizationDataProvider provider,
+        IOptions<LocalizationSettings> opts,
+        ILogger<ClientStringLocalizerService> logger)
+    {
+        _provider = provider;
+        _opts = opts;
+        _logger = logger;
+
+        _provider.TranslationDataSaved += async locale =>
+        {
+            try
+            {
+                await LoadTranslationData(locale, reload: true);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Failed to reload translation data for locale {Locale}", locale);
+            }
+        };
+    }
+
+    public async Task<TranslationData> LoadTranslationData(string locale, bool reload = false)
+    {
+        if (reload || !_translationsData.ContainsKey(locale))
+        {
+            try
+            {
+                var resp = await _provider.GetTranslationDataAsync(locale);
+                if (resp.IsSuccess)
+                {
+                    _translationsData[locale] = resp.Value;
+                }
+                else
+                {
+                    _translationsData.TryAdd(locale, new TranslationData { locale = locale, Words = new() });
+                }
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Loading Translations Error {Locale}", locale);
+            }
+        }
+
+        return _translationsData.TryGetValue(locale, out var data)
+            ? data
+            : new TranslationData { locale = locale, Words = new() };
+    }
+
+    private LocalizedString GetTranslation(string key, params object[] args)
+    {
+        var ret = GetTranslation(key);
+        try
+        {
+            return new LocalizedString(key, string.Format(ret.Value, args), ret.ResourceNotFound);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Formatting Translation Error for key '{Key}'", key);
+        }
+        return ret;
+    }
+
+    private LocalizedString GetTranslation(string key)
+    {
+        var currentLocale = System.Globalization.CultureInfo.CurrentUICulture.TwoLetterISOLanguageName;
+
+        if (currentLocale != "en" && _translationsData.TryGetValue(currentLocale, out var data) && data.Words?.TryGetValue(key, out var value) == true)
+        {
+            string trans = string.IsNullOrEmpty(value) ? key : value;
+            return new LocalizedString(key, trans, false);
+        }
+
+        return new LocalizedString(key, key, true);
+    }
+
+    public LocalizedString this[string name] => GetTranslation(name);
+
+    public LocalizedString this[string name, params object[] arguments] => GetTranslation(name, arguments);
+
+    public IEnumerable<LocalizedString> GetAllStrings(bool includeParentCultures)
+    {
+        var localizedStrings = new List<LocalizedString>();
+        var currentLocale = System.Globalization.CultureInfo.CurrentUICulture.TwoLetterISOLanguageName;
+
+        if (_translationsData.TryGetValue(currentLocale, out var data) && data.Words != null)
+        {
+            foreach (var trans in data.Words)
+            {
+                localizedStrings.Add(new LocalizedString(trans.Key, trans.Value));
+            }
+        }
+
+        return localizedStrings;
+    }
+}

--- a/src/ui/iPath.RazorLib/RazorLibServiceRegistration.cs
+++ b/src/ui/iPath.RazorLib/RazorLibServiceRegistration.cs
@@ -65,9 +65,18 @@ public static class RazorLibServiceRegistration
             services.AddSingleton<ILocalizationDataProvider, FileLocalizaitonProvider>();
         }
 
-        services.AddSingleton<StringLocalizerService>();
-        // register the same singleton for use as IStringLocalizer
-        services.AddSingleton<IStringLocalizer>(p => p.GetRequiredService<StringLocalizerService>());
+        if (WasmClient)
+        {
+            // WASM: lightweight client-side lookup — no auto-translate queue
+            services.AddSingleton<ClientStringLocalizerService>();
+            services.AddSingleton<IStringLocalizer>(p => p.GetRequiredService<ClientStringLocalizerService>());
+        }
+        else
+        {
+            // Server: full localization with auto-translate queue
+            services.AddSingleton<StringLocalizerService>();
+            services.AddSingleton<IStringLocalizer>(p => p.GetRequiredService<StringLocalizerService>());
+        }
         services.AddLocalization();
 
 


### PR DESCRIPTION
…or on WASM client

StringLocalizerService depends on ITranslationJobQueue (server-only). WASM now uses ClientStringLocalizerService — lightweight lookup-only without any server dependencies.